### PR TITLE
Made footer sticky to bottom of page

### DIFF
--- a/Medportal/frontend/src/components/Footer.jsx
+++ b/Medportal/frontend/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 const Footer = () => {
   return (
     <>  
-    <footer className="bg-dark text-light py-4">
+    <footer className="footer mt-auto bg-dark text-light py-4">
         <div className="container text-center">
           <p>&copy; 2024 Med-Portal</p>
           <ul className="list-inline">

--- a/Medportal/frontend/src/main.jsx
+++ b/Medportal/frontend/src/main.jsx
@@ -9,3 +9,8 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>,
 )
+
+// Make footer sticky to bottom of page
+document.documentElement.classList.add('h-100');
+document.body.classList.add('d-flex', 'flex-column', 'h-100'); 
+document.getElementById('root').classList.add('d-flex', 'flex-column', 'h-100'); 


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
- Footer is now sticky to the bottom of the page no matter the content size.
- Reactive for mobile devices as well

Fixes #35 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Additional Context (Please include any Screenshots/gifs if relevant)
![image](https://github.com/blakep7/medical-portal/assets/91240051/54ed89af-8423-415e-abda-f1d0672b8e35)

